### PR TITLE
chore: add link to the repository in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "bin": {
     "borp": "borp.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mcollina/borp"
+  },
   "scripts": {
     "clean": "rm -rf fixtures/*/dist .test-*",
     "lint": "standard | snazzy",


### PR DESCRIPTION
That would make https://www.npmjs.com/package/borp show a link to this repo.