### PR TITLE
Introduce new parameter --post-compile, to allow custom script after typescript compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dist
 .tsimp
 .test-watch*
 coverage-*
+
+# Jetbrains ide config
+.idea

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Note the use of `incremental: true`, which speed up compilation massively.
 * `--pattern` or `-p`, run tests matching the given glob pattern
 * `--reporter` or `-r`, set up a reporter, use a colon to set a file destination. Default: `spec`.
 * `--no-typescript` or `-T`, disable automatic TypeScript compilation if `tsconfig.json` is found.
+* `--post-compile` or `-P`, the path to a file that will be executed after each typescript compilation.
 
 ## Reporters
 

--- a/borp.js
+++ b/borp.js
@@ -33,6 +33,7 @@ const args = parseArgs({
     'expose-gc': { type: 'boolean' },
     help: { type: 'boolean', short: 'h' },
     'no-typescript': { type: 'boolean', short: 'T' },
+    'post-compile': { type: 'string', short: 'P' },
     reporter: {
       type: 'string',
       short: 'r',

--- a/fixtures/ts-cjs-post-compile/package.json
+++ b/fixtures/ts-cjs-post-compile/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/fixtures/ts-cjs-post-compile/postCompile.ts
+++ b/fixtures/ts-cjs-post-compile/postCompile.ts
@@ -1,0 +1,1 @@
+console.log('Doing stuff')

--- a/fixtures/ts-cjs-post-compile/src/add.ts
+++ b/fixtures/ts-cjs-post-compile/src/add.ts
@@ -1,0 +1,4 @@
+
+export function add (x: number, y: number): number {
+  return x + y
+}

--- a/fixtures/ts-cjs-post-compile/test/add.test.ts
+++ b/fixtures/ts-cjs-post-compile/test/add.test.ts
@@ -1,0 +1,7 @@
+import { test } from 'node:test'
+import { add } from '../src/add.js'
+import { strictEqual } from 'node:assert'
+
+test('add', () => {
+  strictEqual(add(1, 2), 3)
+})

--- a/fixtures/ts-cjs-post-compile/test/add2.test.ts
+++ b/fixtures/ts-cjs-post-compile/test/add2.test.ts
@@ -1,0 +1,7 @@
+import { test } from 'node:test'
+import { add } from '../src/add.js'
+import { strictEqual } from 'node:assert'
+
+test('add2', () => {
+  strictEqual(add(3, 2), 5)
+})

--- a/fixtures/ts-cjs-post-compile/tsconfig.json
+++ b/fixtures/ts-cjs-post-compile/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "sourceMap": true,
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "removeComments": true,
+    "newLine": "lf",
+    "noUnusedLocals": true,
+    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "lib": [
+      "ESNext"
+    ],
+    "incremental": true
+  }
+}

--- a/fixtures/ts-esm-post-compile/postCompile.ts
+++ b/fixtures/ts-esm-post-compile/postCompile.ts
@@ -1,0 +1,2 @@
+
+console.log('Doing stuff')

--- a/fixtures/ts-esm-post-compile/src/add.ts
+++ b/fixtures/ts-esm-post-compile/src/add.ts
@@ -1,0 +1,4 @@
+
+export function add (x: number, y: number): number {
+  return x + y
+}

--- a/fixtures/ts-esm-post-compile/test/add.test.ts
+++ b/fixtures/ts-esm-post-compile/test/add.test.ts
@@ -1,0 +1,7 @@
+import { test } from 'node:test'
+import { add } from '../src/add.js'
+import { strictEqual } from 'node:assert'
+
+test('add', () => {
+  strictEqual(add(1, 2), 3)
+})

--- a/fixtures/ts-esm-post-compile/test/add2.test.ts
+++ b/fixtures/ts-esm-post-compile/test/add2.test.ts
@@ -1,0 +1,7 @@
+import { test } from 'node:test'
+import { add } from '../src/add.js'
+import { strictEqual } from 'node:assert'
+
+test('add2', () => {
+  strictEqual(add(3, 2), 5)
+})

--- a/fixtures/ts-esm-post-compile/tsconfig.json
+++ b/fixtures/ts-esm-post-compile/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "sourceMap": true,
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "removeComments": true,
+    "newLine": "lf",
+    "noUnusedLocals": true,
+    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "lib": [
+      "ESNext"
+    ],
+    "incremental": true
+  }
+}

--- a/lib/run.js
+++ b/lib/run.js
@@ -29,6 +29,25 @@ export default async function runWithTypeScript (config) {
   let tscPath
   const typescriptCliArgs = []
 
+  let postCompileFn = async () => {}
+
+  if (config['post-compile']) {
+    postCompileFn = async (outDir) => {
+      const postCompileFile = join(outDir ?? '', config['post-compile']).replace(/\.ts$/, '.js')
+      const postCompileStart = Date.now()
+      const { stdout } = await execa('node', [postCompileFile], { cwd: dirname(tsconfigPath) })
+      pushable.push({
+        type: 'test:diagnostic',
+        data: {
+          nesting: 0,
+          message: `Post compile hook complete (${Date.now() - postCompileStart}ms)`,
+          details: stdout,
+          typescriptCliArgs
+        }
+      })
+    }
+  }
+
   if (tsconfigPath && config.typescript !== false) {
     const tsconfig = JSON.parse(await readFile(tsconfigPath))
     const _require = createRequire(tsconfigPath)
@@ -60,20 +79,7 @@ export default async function runWithTypeScript (config) {
           }
         })
 
-        if (config['post-compile']) {
-          const postCompileStart = Date.now()
-          const postCompileFile = join(outDir ?? '', config['post-compile']).replace(/\.ts$/, '.js')
-          const { stdout } = await execa('node', [postCompileFile], { cwd: dirname(tsconfigPath) })
-          pushable.push({
-            type: 'test:diagnostic',
-            data: {
-              nesting: 0,
-              message: `Post compile hook complete (${Date.now() - postCompileStart}ms)`,
-              details: stdout,
-              typescriptCliArgs
-            }
-          })
-        }
+        await postCompileFn(outDir)
       }
     }
   }
@@ -127,20 +133,7 @@ export default async function runWithTypeScript (config) {
           }
         })
 
-        if (config['post-compile']) {
-          const postCompileStart = Date.now()
-          const postCompileFile = join(outDir, config['post-compile']).replace(/\.ts$/, '.js')
-          const { stdout } = await execa('node', [postCompileFile], { cwd: dirname(tsconfigPath) })
-          pushable.push({
-            type: 'test:diagnostic',
-            data: {
-              nesting: 0,
-              message: `Post compile hook complete (${Date.now() - postCompileStart}ms)`,
-              details: stdout,
-              typescriptCliArgs
-            }
-          })
-        }
+        await postCompileFn(outDir)
 
         p.resolve()
       }

--- a/lib/run.js
+++ b/lib/run.js
@@ -115,7 +115,7 @@ export default async function runWithTypeScript (config) {
     let outDir = ''
     if (config['post-compile'] && tsconfigPath) {
       const tsconfig = JSON.parse(await readFile(tsconfigPath))
-      outDir = tsconfig.compilerOptions.outDir ?? ''
+      outDir = tsconfig.compilerOptions.outDir
     }
     let start = Date.now()
     tscChild = execa('node', [tscPath, ...typescriptCliArgs], { cwd })

--- a/lib/run.js
+++ b/lib/run.js
@@ -34,6 +34,11 @@ export default async function runWithTypeScript (config) {
     const _require = createRequire(tsconfigPath)
     const typescriptPathCWD = _require.resolve('typescript')
     tscPath = join(typescriptPathCWD, '..', '..', 'bin', 'tsc')
+    const outDir = tsconfig.compilerOptions.outDir
+    if (outDir) {
+      prefix = join(dirname(tsconfigPath), outDir)
+    }
+
     if (tscPath) {
       // This will throw if we cannot find the `tsc` binary
       await access(tscPath)
@@ -54,11 +59,22 @@ export default async function runWithTypeScript (config) {
             typescriptCliArgs
           }
         })
+
+        if (config['post-compile']) {
+          const start = Date.now()
+          const postCompileFile = join(outDir, config['post-compile']).replace(/\.ts$/, '.js')
+          const { stdout } = await execa('node', [postCompileFile], { cwd: dirname(tsconfigPath) })
+          pushable.push({
+            type: 'test:diagnostic',
+            data: {
+              nesting: 0,
+              message: `Post compile hook complete (${Date.now() - start}ms)`,
+              details: stdout,
+              typescriptCliArgs
+            }
+          })
+        }
       }
-    }
-    const outDir = tsconfig.compilerOptions.outDir
-    if (outDir) {
-      prefix = join(dirname(tsconfigPath), outDir)
     }
   }
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -61,14 +61,14 @@ export default async function runWithTypeScript (config) {
         })
 
         if (config['post-compile']) {
-          const start = Date.now()
-          const postCompileFile = join(outDir, config['post-compile']).replace(/\.ts$/, '.js')
+          const postCompileStart = Date.now()
+          const postCompileFile = join(outDir ?? '', config['post-compile']).replace(/\.ts$/, '.js')
           const { stdout } = await execa('node', [postCompileFile], { cwd: dirname(tsconfigPath) })
           pushable.push({
             type: 'test:diagnostic',
             data: {
               nesting: 0,
-              message: `Post compile hook complete (${Date.now() - start}ms)`,
+              message: `Post compile hook complete (${Date.now() - postCompileStart}ms)`,
               details: stdout,
               typescriptCliArgs
             }
@@ -106,10 +106,15 @@ export default async function runWithTypeScript (config) {
   if (config.watch) {
     typescriptCliArgs.push('--watch')
     p = deferred()
+    let outDir = ''
+    if (config['post-compile'] && tsconfigPath) {
+      const tsconfig = JSON.parse(await readFile(tsconfigPath))
+      outDir = tsconfig.compilerOptions.outDir ?? ''
+    }
     let start = Date.now()
     tscChild = execa('node', [tscPath, ...typescriptCliArgs], { cwd })
     tscChild.stdout.setEncoding('utf8')
-    tscChild.stdout.on('data', (data) => {
+    tscChild.stdout.on('data', async (data) => {
       if (data.includes('File change detected')) {
         start = Date.now()
       } else if (data.includes('Watching for file changes')) {
@@ -121,6 +126,21 @@ export default async function runWithTypeScript (config) {
             typescriptCliArgs
           }
         })
+
+        if (config['post-compile']) {
+          const postCompileStart = Date.now()
+          const postCompileFile = join(outDir, config['post-compile']).replace(/\.ts$/, '.js')
+          const { stdout } = await execa('node', [postCompileFile], { cwd: dirname(tsconfigPath) })
+          pushable.push({
+            type: 'test:diagnostic',
+            data: {
+              nesting: 0,
+              message: `Post compile hook complete (${Date.now() - postCompileStart}ms)`,
+              details: stdout,
+              typescriptCliArgs
+            }
+          })
+        }
 
         p.resolve()
       }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -89,13 +89,24 @@ test('gh reporter', async () => {
   strictEqual(stdout.indexOf('::notice') >= 0, true)
 })
 
-test('post-compile hook should be correctly called', async () => {
+test('Post compile script should be executed when --post-compile  is sent with esm', async () => {
   const cwd = join(import.meta.url, '..', 'fixtures', 'ts-esm-post-compile')
   const { stdout } = await execa('node', [
     borp,
     '--post-compile=postCompile.ts'
   ], {
     cwd
+  })
+
+  strictEqual(stdout.indexOf('Post compile hook complete') >= 0, true, 'Post compile message should be found in stdout')
+})
+
+test('Post compile script should be executed when --post-compile  is sent with cjs', async () => {
+  const { stdout } = await execa('node', [
+    borp,
+    '--post-compile=postCompile.ts'
+  ], {
+    cwd: join(import.meta.url, '..', 'fixtures', 'ts-cjs-post-compile')
   })
 
   strictEqual(stdout.indexOf('Post compile hook complete') >= 0, true, 'Post compile message should be found in stdout')

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -88,3 +88,15 @@ test('gh reporter', async () => {
 
   strictEqual(stdout.indexOf('::notice') >= 0, true)
 })
+
+test('post-compile hook should be correctly called', async () => {
+  const cwd = join(import.meta.url, '..', 'fixtures', 'ts-esm-post-compile')
+  const { stdout } = await execa('node', [
+    borp,
+    '--post-compile=postCompile.ts'
+  ], {
+    cwd
+  })
+
+  strictEqual(stdout.indexOf('Post compile hook complete') >= 0, true, 'Post compile message should be found in stdout')
+})

--- a/test/watch.test.js
+++ b/test/watch.test.js
@@ -110,7 +110,7 @@ test('add', () => {
   await completed
 })
 
-test('watch with post compile hook', async (t) => {
+test('watch with post compile hook should call the hook the right number of times', async (t) => {
   const { strictEqual, completed, ok } = tspl(t, { plan: 2 })
 
   const dir = path.resolve(await mkdtemp('.test-watch-with-post-compile-hook'))

--- a/test/watch.test.js
+++ b/test/watch.test.js
@@ -148,7 +148,7 @@ test('watch with post compile hook', async (t) => {
   const diagnosticListenerFn = (test) => {
     if (test.type === 'test:diagnostic' && test.data.message.includes('Post compile hook complete')) {
       if (++postCompileEventCount === 2) {
-        ok(true, 'Post compile hook ran')
+        ok(true, 'Post compile hook ran twice')
         stream.removeListener('data', diagnosticListenerFn)
       }
     }

--- a/test/watch.test.js
+++ b/test/watch.test.js
@@ -109,3 +109,64 @@ test('add', () => {
 
   await completed
 })
+
+test('watch with post compile hook', async (t) => {
+  const { strictEqual, completed, ok } = tspl(t, { plan: 2 })
+
+  const dir = path.resolve(await mkdtemp('.test-watch-with-post-compile-hook'))
+  await cp(join(import.meta.url, '..', 'fixtures', 'ts-esm-post-compile'), dir, {
+    recursive: true
+  })
+
+  const controller = new AbortController()
+  t.after(async () => {
+    controller.abort()
+    try {
+      await rm(dir, { recursive: true, retryDelay: 100, maxRetries: 10 })
+    } catch {}
+  })
+
+  const config = {
+    'post-compile': 'postCompile.ts',
+    files: [],
+    cwd: dir,
+    signal: controller.signal,
+    watch: true
+  }
+
+  const stream = await runWithTypeScript(config)
+
+  const fn = (test) => {
+    if (test.type === 'test:fail') {
+      strictEqual(test.data.name, 'add')
+      stream.removeListener('data', fn)
+    }
+  }
+  stream.on('data', fn)
+
+  let postCompileEventCount = 0
+  const diagnosticListenerFn = (test) => {
+    if (test.type === 'test:diagnostic' && test.data.message.includes('Post compile hook complete')) {
+      if (++postCompileEventCount === 2) {
+        ok(true, 'Post compile hook ran')
+        stream.removeListener('data', diagnosticListenerFn)
+      }
+    }
+  }
+
+  stream.on('data', diagnosticListenerFn)
+
+  const toWrite = `
+import { test } from 'node:test'
+import { add } from '../src/add.js'
+import { strictEqual } from 'node:assert'
+
+test('add', () => {
+  strictEqual(add(1, 2), 4)
+})
+`
+  const file = path.join(dir, 'test', 'add.test.ts')
+  await writeFile(file, toWrite)
+
+  await completed
+})


### PR DESCRIPTION
resolve #21 

Hello, 
this PR introduce a new parameter `--post-compile` with which client can define a script which will be executed every time the compile is performed.

```shell
borp --post-compile=test/scripts/borpPostCompile.ts
```

The next one is enough to replace all the alias in the compiled code.

```typescript
// File: test/scripts/borpPostCompile.ts
import { replaceTscAliasPaths } from "tsc-alias"
replaceTscAliasPaths({})
```