### PR TITLE
Introduce c8 check coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ npm i borp --save-dev
 
 ```bash
 borp --coverage
+
+# with check coverage active
+borp --coverage --check-coverage --lines 95
 ```
 
 Borp will automatically run all tests files matching `*.test.{js|ts}`.
@@ -97,7 +100,12 @@ Note the use of `incremental: true`, which speed up compilation massively.
 * `--reporter` or `-r`, set up a reporter, use a colon to set a file destination. Default: `spec`.
 * `--no-typescript` or `-T`, disable automatic TypeScript compilation if `tsconfig.json` is found.
 * `--post-compile` or `-P`, the path to a file that will be executed after each typescript compilation.
-
+* `--check-coverage`, enables c8 check coverage; default is false
+### Check coverage options
+* `--lines`, set the lines threshold when check coverage is active; default is 100
+* `--functions`, set the functions threshold when check coverage is active; default is 100
+* `--statements`, set the statements threshold when check coverage is active; default is 100
+* `--branches`, set the branches threshold when check coverage is active; default is 100
 ## Reporters
 
 Here are the available reporters:

--- a/README.md
+++ b/README.md
@@ -25,30 +25,30 @@ Borp will automatically run all tests files matching `*.test.{js|ts}`.
 .
 ├── src
 │   ├── lib
-│   │   └── add.ts
+│   │   └── math.ts
 │   └── test
-│       └── add.test.ts
+│       └── math.test.ts
 └── tsconfig.json
 
 ```
 
-As an example, consider having a `src/lib/add.ts` file  
+As an example, consider having a `src/lib/math.ts` file  
 
 ```typescript
-export function add (x: number, y: number): number {
+export function math (x: number, y: number): number {
   return x + y
 }
 ```
 
-and a `src/test/add.test.ts` file:
+and a `src/test/math.test.ts` file:
 
 ```typescript
 import { test } from 'node:test'
-import { add } from '../lib/add.js'
+import { math } from '../lib/math.js'
 import { strictEqual } from 'node:assert'
 
-test('add', () => {
-  strictEqual(add(1, 2), 3)
+test('math', () => {
+  strictEqual(math(1, 2), 3)
 })
 ```
 

--- a/borp.js
+++ b/borp.js
@@ -29,7 +29,6 @@ const args = parseArgs({
     concurrency: { type: 'string', short: 'c', default: os.availableParallelism() - 1 + '' },
     coverage: { type: 'boolean', short: 'C' },
     timeout: { type: 'string', short: 't', default: '30000' },
-    'check-coverage': { type: 'boolean', short: 'V' },
     'coverage-exclude': { type: 'string', short: 'X', multiple: true },
     ignore: { type: 'string', short: 'i', multiple: true },
     'expose-gc': { type: 'boolean' },
@@ -41,7 +40,12 @@ const args = parseArgs({
       short: 'r',
       default: ['spec'],
       multiple: true
-    }
+    },
+    'check-coverage': { type: 'boolean' },
+    lines: { type: 'string', default: '100' },
+    branches: { type: 'string', default: '100' },
+    functions: { type: 'string', default: '100' },
+    statements: { type: 'string', default: '100' }
   },
   allowPositionals: true
 })
@@ -140,10 +144,10 @@ try {
 
     if (args.values['check-coverage']) {
       await checkCoverages({
-        lines: 100,
-        functions: 100,
-        branches: 100,
-        statements: 100,
+        lines: parseInt(args.values.lines),
+        functions: parseInt(args.values.functions),
+        branches: parseInt(args.values.branches),
+        statements: parseInt(args.values.statements),
         ...args
       }, report)
     }

--- a/borp.js
+++ b/borp.js
@@ -10,6 +10,7 @@ import posix from 'node:path/posix'
 import runWithTypeScript from './lib/run.js'
 import githubReporter from '@reporters/github'
 import { Report } from 'c8'
+import { checkCoverages } from 'c8/lib/commands/check-coverage.js'
 import os from 'node:os'
 import { execa } from 'execa'
 
@@ -28,6 +29,7 @@ const args = parseArgs({
     concurrency: { type: 'string', short: 'c', default: os.availableParallelism() - 1 + '' },
     coverage: { type: 'boolean', short: 'C' },
     timeout: { type: 'string', short: 't', default: '30000' },
+    'check-coverage': { type: 'boolean', short: 'V' },
     'coverage-exclude': { type: 'string', short: 'X', multiple: true },
     ignore: { type: 'string', short: 'i', multiple: true },
     'expose-gc': { type: 'boolean' },
@@ -136,6 +138,15 @@ try {
       exclude
     })
 
+    if (args.values['check-coverage']) {
+      await checkCoverages({
+        lines: 100,
+        functions: 100,
+        branches: 100,
+        statements: 100,
+        ...args
+      }, report)
+    }
     await report.run()
   }
   /* c8 ignore next 3 */

--- a/fixtures/ts-esm-check-coverage/src/math.ts
+++ b/fixtures/ts-esm-check-coverage/src/math.ts
@@ -1,0 +1,8 @@
+
+export function add (x: number, y: number): number {
+  return x + y
+}
+
+export function sub (x: number, y: number): number {
+  return x - y
+}

--- a/fixtures/ts-esm-check-coverage/test/add.test.ts
+++ b/fixtures/ts-esm-check-coverage/test/add.test.ts
@@ -1,0 +1,7 @@
+import { test } from 'node:test'
+import { add } from '../src/math.js'
+import { strictEqual } from 'node:assert'
+
+test('add', () => {
+  strictEqual(add(1, 2), 3)
+})

--- a/fixtures/ts-esm-check-coverage/tsconfig.json
+++ b/fixtures/ts-esm-check-coverage/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "sourceMap": true,
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "removeComments": true,
+    "newLine": "lf",
+    "noUnusedLocals": true,
+    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "lib": [
+      "ESNext"
+    ],
+    "incremental": true
+  }
+}

--- a/test/coverage.test.js
+++ b/test/coverage.test.js
@@ -36,7 +36,7 @@ test('coverage excludes', async () => {
   match(res.stdout, /add2\.test\.ts/)
 })
 
-test('borp should return right error in case of check coverage active with default values failure', async (t) => {
+test('borp should return right error when check coverage is active with default thresholds', async (t) => {
   try {
     await execa('node', [
       borp,
@@ -52,8 +52,32 @@ test('borp should return right error in case of check coverage active with defau
     }
 
     equal(e.exitCode, 1)
-    match(e.stderr, /ERROR: Coverage for lines/)
-    match(e.stderr, /ERROR: Coverage for functions/)
-    match(e.stderr, /ERROR: Coverage for statements/)
+    match(e.stderr, /ERROR: Coverage for lines \(75%\) does not meet global threshold \(100%\)/)
+    match(e.stderr, /ERROR: Coverage for functions \(50%\) does not meet global threshold \(100%\)/)
+    match(e.stderr, /ERROR: Coverage for statements \(75%\) does not meet global threshold \(100%\)/)
+  }
+})
+
+test('borp should return right error when check coverage is active with defined thresholds', async (t) => {
+  try {
+    await execa('node', [
+      borp,
+      '--coverage',
+      '--check-coverage',
+      '--lines=80',
+      '--functions=50',
+      '--statements=0',
+      '--branches=100'
+    ], {
+      cwd: join(import.meta.url, '..', 'fixtures', 'ts-esm-check-coverage')
+    })
+    fail('Should not complete borp without error')
+  } catch (e) {
+    if (e instanceof AssertionError) {
+      throw e
+    }
+
+    equal(e.exitCode, 1)
+    match(e.stderr, /ERROR: Coverage for lines \(75%\) does not meet global threshold \(80%\)/)
   }
 })

--- a/test/coverage.test.js
+++ b/test/coverage.test.js
@@ -1,5 +1,5 @@
 import { test } from 'node:test'
-import { match, doesNotMatch } from 'node:assert'
+import { match, doesNotMatch, fail, equal, AssertionError } from 'node:assert'
 import { execa } from 'execa'
 import { join } from 'desm'
 
@@ -34,4 +34,26 @@ test('coverage excludes', async () => {
   // The test files are shown
   match(res.stdout, /add\.test\.ts/)
   match(res.stdout, /add2\.test\.ts/)
+})
+
+test('borp should return right error in case of check coverage active with default values failure', async (t) => {
+  try {
+    await execa('node', [
+      borp,
+      '--coverage',
+      '--check-coverage'
+    ], {
+      cwd: join(import.meta.url, '..', 'fixtures', 'ts-esm-check-coverage')
+    })
+    fail('Should not complete borp without error')
+  } catch (e) {
+    if (e instanceof AssertionError) {
+      throw e
+    }
+
+    equal(e.exitCode, 1)
+    match(e.stderr, /ERROR: Coverage for lines/)
+    match(e.stderr, /ERROR: Coverage for functions/)
+    match(e.stderr, /ERROR: Coverage for statements/)
+  }
 })


### PR DESCRIPTION
resolve: #23 

Hello @mcollina, 
this PR introduce five new parameters which can be used to activate the c8 check coverage and configure his thresholds. 

```shell
# default 100% coverage requested
borp --coverage --check-coverage

# configured thresholds
borp --coverage --check-coverage --lines 99 --functions 98 --branches 95 --statements 99
```