### PR TITLE
feat: replace JSON.parse with typescript builtin config parser

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -3,8 +3,9 @@ import { glob } from 'glob'
 import { findUp } from 'find-up'
 import { createRequire } from 'node:module'
 import { join, dirname } from 'node:path'
-import { access, readFile } from 'node:fs/promises'
+import { access } from 'node:fs/promises'
 import { execa } from 'execa'
+import { parseJsonConfigFileContent, readConfigFile, sys } from 'typescript'
 
 function deferred () {
   let resolve
@@ -17,7 +18,7 @@ function deferred () {
 }
 
 function enableSourceMapSupport (tsconfig) {
-  if (!tsconfig?.compilerOptions?.sourceMap) {
+  if (!tsconfig?.options?.sourceMap) {
     return
   }
 
@@ -56,13 +57,19 @@ export default async function runWithTypeScript (config) {
   }
 
   if (tsconfigPath && config.typescript !== false) {
-    const tsconfig = JSON.parse(await readFile(tsconfigPath))
+    const configFile = readConfigFile(tsconfigPath, sys.readFile)
+    const tsconfig = parseJsonConfigFileContent(
+      configFile.config,
+      sys,
+      dirname(tsconfigPath)
+    )
+
     const _require = createRequire(tsconfigPath)
     const typescriptPathCWD = _require.resolve('typescript')
     tscPath = join(typescriptPathCWD, '..', '..', 'bin', 'tsc')
-    const outDir = tsconfig.compilerOptions.outDir
+    const outDir = tsconfig.options.outDir
     if (outDir) {
-      prefix = join(dirname(tsconfigPath), outDir)
+      prefix = outDir
     }
 
     enableSourceMapSupport(tsconfig)
@@ -73,7 +80,7 @@ export default async function runWithTypeScript (config) {
 
       // Watch is handled aftterwards
       if (!config.watch) {
-        if (Array.isArray(tsconfig.references) && tsconfig.references.length > 0) {
+        if (Array.isArray(tsconfig.projectReferences) && tsconfig.projectReferences.length > 0) {
           typescriptCliArgs.push('--build')
         }
         const start = Date.now()
@@ -123,8 +130,14 @@ export default async function runWithTypeScript (config) {
     p = deferred()
     let outDir = ''
     if (config['post-compile'] && tsconfigPath) {
-      const tsconfig = JSON.parse(await readFile(tsconfigPath))
-      outDir = tsconfig.compilerOptions.outDir
+      const configFile = readConfigFile(tsconfigPath, sys.readFile)
+      const tsconfig = parseJsonConfigFileContent(
+        configFile.config,
+        sys,
+        dirname(tsconfigPath)
+      )
+
+      outDir = tsconfig.options.outDir
 
       enableSourceMapSupport(tsconfig)
     }

--- a/lib/run.js
+++ b/lib/run.js
@@ -5,7 +5,6 @@ import { createRequire } from 'node:module'
 import { join, dirname } from 'node:path'
 import { access } from 'node:fs/promises'
 import { execa } from 'execa'
-import { parseJsonConfigFileContent, readConfigFile, sys } from 'typescript'
 
 function deferred () {
   let resolve
@@ -57,6 +56,9 @@ export default async function runWithTypeScript (config) {
   }
 
   if (tsconfigPath && config.typescript !== false) {
+    const _require = createRequire(tsconfigPath)
+    const { parseJsonConfigFileContent, readConfigFile, sys } = _require('typescript')
+
     const configFile = readConfigFile(tsconfigPath, sys.readFile)
     const tsconfig = parseJsonConfigFileContent(
       configFile.config,
@@ -64,7 +66,6 @@ export default async function runWithTypeScript (config) {
       dirname(tsconfigPath)
     )
 
-    const _require = createRequire(tsconfigPath)
     const typescriptPathCWD = _require.resolve('typescript')
     tscPath = join(typescriptPathCWD, '..', '..', 'bin', 'tsc')
     const outDir = tsconfig.options.outDir
@@ -130,6 +131,9 @@ export default async function runWithTypeScript (config) {
     p = deferred()
     let outDir = ''
     if (config['post-compile'] && tsconfigPath) {
+      const _require = createRequire(tsconfigPath)
+      const { parseJsonConfigFileContent, readConfigFile, sys } = _require('typescript')
+
       const configFile = readConfigFile(tsconfigPath, sys.readFile)
       const tsconfig = parseJsonConfigFileContent(
         configFile.config,


### PR DESCRIPTION
As mentioned in issue #42, borp currently encounters errors when parsing `tsconfig.json` with comments (and more non standard JSON syntax) because it uses `JSON.parse` and does not support features available in `tsc`, such as the ability to extend other configuration files. 

`typescript` provides a few functions to access its internal configuration parser, which can handle all of these cases and provide `borp` with the exact same configuration as `tsc` will have