### PR TITLE
Support local custom reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ borp --coverage
 
 # with check coverage active
 borp --coverage --check-coverage --lines 95
+
+# with a node_modules located reporter
+borp --reporter foo
+
+# with a node_modules located reporter writing to stderr
+borp --reporter foo:stderr
+
+# with a local custom reporter
+borp --reporter ./lib/some-reporter.mjs
 ```
 
 Borp will automatically run all tests files matching `*.test.{js|ts}`.
@@ -98,7 +107,7 @@ Note the use of `incremental: true`, which speed up compilation massively.
 * `--ignore` or `-i`, ignore a glob pattern, and not look for tests there
 * `--expose-gc`, exposes the gc() function to tests
 * `--pattern` or `-p`, run tests matching the given glob pattern
-* `--reporter` or `-r`, set up a reporter, use a colon to set a file destination. Default: `spec`.
+* `--reporter` or `-r`, set up a reporter, use a colon to set a file destination. Reporter may either be a module name resolvable by standard `node_modules` resolution, or a path to a script relative to the process working directory (must be an ESM script). Default: `spec`.
 * `--no-typescript` or `-T`, disable automatic TypeScript compilation if `tsconfig.json` is found.
 * `--post-compile` or `-P`, the path to a file that will be executed after each typescript compilation.
 * `--check-coverage`, enables c8 check coverage; default is false

--- a/fixtures/relative-reporter/lib/add.js
+++ b/fixtures/relative-reporter/lib/add.js
@@ -1,0 +1,3 @@
+export function add (x, y) {
+  return x + y
+}

--- a/fixtures/relative-reporter/reporter.js
+++ b/fixtures/relative-reporter/reporter.js
@@ -1,0 +1,24 @@
+'use strict'
+
+import { Transform } from 'node:stream'
+
+const testReporter = new Transform({
+  writableObjectMode: true,
+  transform (event, encoding, callback) {
+    switch (event.type) {
+      case 'test:pass': {
+        return callback(null, `passed: ${event.data.file}\n`)
+      }
+
+      case 'test:fail': {
+        return callback(null, `failed: ${event.data.file}\n`)
+      }
+
+      default: {
+        callback(null, null)
+      }
+    }
+  }
+})
+
+export default testReporter

--- a/fixtures/relative-reporter/test/add.test.js
+++ b/fixtures/relative-reporter/test/add.test.js
@@ -1,0 +1,7 @@
+import { test } from 'node:test'
+import { add } from '../lib/add.js'
+import { strictEqual } from 'node:assert'
+
+test('add', () => {
+  strictEqual(add(1, 2), 3)
+})

--- a/fixtures/relative-reporter/test/add2.test.js
+++ b/fixtures/relative-reporter/test/add2.test.js
@@ -1,0 +1,7 @@
+import { test } from 'node:test'
+import { add } from '../lib/add.js'
+import { strictEqual } from 'node:assert'
+
+test('add2', () => {
+  strictEqual(add(3, 2), 5)
+})

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -74,6 +74,19 @@ test('reporter from node_modules', async () => {
   strictEqual(stdout.indexOf('tests 2') >= 0, true)
 })
 
+test('reporter from relative path', async () => {
+  const cwd = join(import.meta.url, '..', 'fixtures', 'relative-reporter')
+  const { stdout } = await execa('node', [
+    borp,
+    '--reporter=./fixtures/relative-reporter/reporter.js'
+  ], {
+    cwd
+  })
+
+  strictEqual(/passed:.+add\.test\.js/.test(stdout), true)
+  strictEqual(/passed:.+add2\.test\.js/.test(stdout), true)
+})
+
 test('gh reporter', async () => {
   const cwd = join(import.meta.url, '..', 'fixtures', 'js-esm')
   const { stdout } = await execa('node', [


### PR DESCRIPTION
This PR resolves #68. In short, `borp` currently does not support local custom reporters, only those that are installed in a `node_modules` directory somewhere. This PR rectifies that problem by first trying to load the supplied reporter relative to the process working directory. If that fails, fallback to the current implementation.

Documentation has also been improved to clarify how to use the `--reporter` switch.