### PR TITLE
Support parsing glob strings for files target

### DIFF
--- a/fixtures/files-glob/lib/add.js
+++ b/fixtures/files-glob/lib/add.js
@@ -1,0 +1,3 @@
+export function add (x, y) {
+  return x + y
+}

--- a/fixtures/files-glob/test1/add.test.js
+++ b/fixtures/files-glob/test1/add.test.js
@@ -1,0 +1,7 @@
+import { test } from 'node:test'
+import { add } from '../lib/add.js'
+import { strictEqual } from 'node:assert'
+
+test('add', () => {
+  strictEqual(add(1, 2), 3)
+})

--- a/fixtures/files-glob/test2/nested/add2.test.js
+++ b/fixtures/files-glob/test2/nested/add2.test.js
@@ -1,0 +1,7 @@
+import { test } from 'node:test'
+import { add } from '../../lib/add.js'
+import { strictEqual } from 'node:assert'
+
+test('add2', () => {
+  strictEqual(add(3, 2), 5)
+})

--- a/lib/run.js
+++ b/lib/run.js
@@ -196,6 +196,16 @@ export default async function runWithTypeScript (config) {
     if (prefix) {
       files = files.map((file) => join(prefix, file.replace(/ts$/, 'js')))
     }
+    const expandedFiles = []
+    for (let i = 0; i < files.length; i += 1) {
+      if (files[i].includes('*') === false) {
+        expandedFiles.push(files[i])
+        continue
+      }
+      const parsed = await glob(files[i].replace(/^['"]/, '').replace(/['"]$/, ''), { ignore, cwd, windowsPathsNoEscape: true })
+      Array.prototype.push.apply(expandedFiles, parsed)
+    }
+    files = expandedFiles
   } else if (config.pattern) {
     let pattern = config.pattern
     if (prefix) {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -89,6 +89,19 @@ test('gh reporter', async () => {
   strictEqual(stdout.indexOf('::notice') >= 0, true)
 })
 
+test('interprets globs for files', async () => {
+  const cwd = join(import.meta.url, '..', 'fixtures', 'files-glob')
+  const { stdout } = await execa('node', [
+    borp,
+    '\'test1/*.test.js\'',
+    '\'test2/**/*.test.js\''
+  ], {
+    cwd
+  })
+
+  strictEqual(stdout.indexOf('tests 2') >= 0, true)
+})
+
 test('Post compile script should be executed when --post-compile  is sent with esm', async () => {
   const cwd = join(import.meta.url, '..', 'fixtures', 'ts-esm-post-compile')
   const { stdout } = await execa('node', [


### PR DESCRIPTION
Currently, `borp 'test/some/**/*.glob'` does not expand the glob. This PR rectifies that by expanding all strings that look like they have a globstar pattern.