### PR TITLE
Support exclude globs, e.g. `!some/**/deep_path/**/*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ borp --reporter foo:stderr
 
 # with a local custom reporter
 borp --reporter ./lib/some-reporter.mjs
+
+# matching all test.js files except ones in nested node_modules directories
+borp 'test/**/*.test.js' '!test/**/node_modules/**/*.test.js'
 ```
 
 Borp will automatically run all tests files matching `*.test.{js|ts}`.
@@ -137,6 +140,9 @@ full path to some yaml file.
 The current supported options are:
 
 + `files` (string[]): An array of test files to include. Globs are supported.
+  Note: any glob that starts with a `!` (bang character) will be treated as
+  an ignore glob, e.g. `'!test/**/node_modules/**/*'` will ignore all files
+  in nested `node_modules` directories that would otherwise be matched.
 + `reporters` (string[]): An array of reporters to use. May be relative path
 strings, or module name strings.
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -196,15 +196,27 @@ export default async function runWithTypeScript (config) {
     if (prefix) {
       files = files.map((file) => join(prefix, file.replace(/ts$/, 'js')))
     }
+
     const expandedFiles = []
+    const globs = []
     for (let i = 0; i < files.length; i += 1) {
       if (files[i].includes('*') === false) {
         expandedFiles.push(files[i])
         continue
       }
-      const parsed = await glob(files[i].replace(/^['"]/, '').replace(/['"]$/, ''), { ignore, cwd, windowsPathsNoEscape: true })
+      const pattern = files[i].replace(/^['"]/, '').replace(/['"]$/, '')
+      if (pattern[0] === '!') {
+        ignore.push(pattern.slice(1))
+        continue
+      }
+      globs.push(pattern)
+    }
+
+    if (globs.length > 0) {
+      const parsed = await glob(globs, { ignore, cwd, windowsPathsNoEscape: true })
       Array.prototype.push.apply(expandedFiles, parsed)
     }
+
     files = expandedFiles
   } else if (config.pattern) {
     let pattern = config.pattern

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -112,7 +112,24 @@ test('interprets globs for files', async () => {
     cwd
   })
 
-  strictEqual(stdout.indexOf('tests 2') >= 0, true)
+  strictEqual(stdout.indexOf('✔ add') >= 0, true)
+  strictEqual(stdout.indexOf('✔ add2') >= 0, true)
+  strictEqual(stdout.indexOf('✔ a thing'), -1)
+})
+
+test('interprets globs for files with an ignore rule', async () => {
+  const cwd = join(import.meta.url, '..', 'fixtures', 'files-glob')
+  const { stdout } = await execa('node', [
+    borp,
+    '\'**/*.test.js\'',
+    '\'!test1/**/node_modules/**/*\''
+  ], {
+    cwd
+  })
+
+  strictEqual(stdout.indexOf('✔ add') >= 0, true)
+  strictEqual(stdout.indexOf('✔ add2') >= 0, true)
+  strictEqual(stdout.indexOf('✔ a thing'), -1)
 })
 
 test('Post compile script should be executed when --post-compile  is sent with esm', async () => {


### PR DESCRIPTION
This PR tweaks the glob support to recognize globs that are meant to _exclude_ matching files.