### PR TITLE
fix: Don't let concurrenct default to zero.

### DIFF
--- a/borp.js
+++ b/borp.js
@@ -34,7 +34,7 @@ const args = parseArgs({
     only: { type: 'boolean', short: 'o' },
     watch: { type: 'boolean', short: 'w' },
     pattern: { type: 'string', short: 'p' },
-    concurrency: { type: 'string', short: 'c', default: os.availableParallelism() - 1 + '' },
+    concurrency: { type: 'string', short: 'c', default: (os.availableParallelism() - 1 || 1) + '' },
     coverage: { type: 'boolean', short: 'C' },
     timeout: { type: 'string', short: 't', default: '30000' },
     'no-timeout': { type: 'boolean' },


### PR DESCRIPTION
see #160 

Currently, the default value for concurrency is `os.availableParallelism() - 1`, which for most system is probably ok, since that function usually returns a value greater than 1.  But for those systems that return a value of 1, the default would then be zero, which will cause an OUT_OF_RANGE error later on down the call chain.

This fix will make the default value 1 if the `os.availableParallelism() - 1` is zero.  This doesn't change anything if the user specifys a 1 for the concurrency flag.

