### PR TITLE
fix: silence node:test recursion warning; add Node 26 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x, 24.x, 25.x]
+        node-version: [22.x, 24.x, 25.x, 26.x]
         os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -4,6 +4,21 @@ import { run } from 'node:test'
 import { glob } from 'glob'
 import { join } from 'node:path'
 
+// node:test's run() refuses to spawn files when NODE_TEST_CONTEXT is set
+// (https://github.com/nodejs/node/commit/d5c9adf3df). We're inside such a
+// child here, so unset it just for the call. Doing it at module scope would
+// also fool lazyBootstrapRoot into installing a spec reporter on stdout,
+// corrupting the v8-serialized stream our parent (borp) is reading.
+function runIsolated (opts) {
+  const saved = process.env.NODE_TEST_CONTEXT
+  delete process.env.NODE_TEST_CONTEXT
+  try {
+    return run(opts)
+  } finally {
+    if (saved !== undefined) process.env.NODE_TEST_CONTEXT = saved
+  }
+}
+
 async function consumeStream (stream) {
   // eslint-disable-next-line no-unused-vars
   for await (const _ of stream) {
@@ -15,7 +30,7 @@ test('ts-esm', async () => {
   const cwd = join(import.meta.url, '..', 'fixtures', 'ts-esm')
   const files = await glob('**/*.test.ts', { cwd, absolute: true })
 
-  const stream = run({ files, cwd })
+  const stream = runIsolated({ files, cwd })
 
   const names = new Set(['add', 'add2'])
 
@@ -31,7 +46,7 @@ test('ts-esm with named files', async () => {
   const cwd = join(import.meta.url, '..', 'fixtures', 'ts-esm')
   const files = [join(cwd, 'test/add.test.ts')]
 
-  const stream = run({ files, cwd })
+  const stream = runIsolated({ files, cwd })
 
   const names = new Set(['add'])
 
@@ -47,7 +62,7 @@ test('pattern', async () => {
   const cwd = join(import.meta.url, '..', 'fixtures', 'ts-esm')
   const files = await glob('test/*2.test.ts', { cwd, absolute: true })
 
-  const stream = run({ files, cwd })
+  const stream = runIsolated({ files, cwd })
 
   const names = new Set(['add2'])
 
@@ -63,7 +78,7 @@ test('no files', async () => {
   const cwd = join(import.meta.url, '..', 'fixtures', 'ts-esm')
   const files = await glob('**/*.test.ts', { cwd, absolute: true })
 
-  const stream = run({ files, cwd })
+  const stream = runIsolated({ files, cwd })
 
   const names = new Set(['add', 'add2'])
 
@@ -79,7 +94,7 @@ test('ts-esm2', async () => {
   const cwd = join(import.meta.url, '..', 'fixtures', 'ts-esm2')
   const files = await glob('**/*.test.ts', { cwd, absolute: true })
 
-  const stream = run({ files, cwd })
+  const stream = runIsolated({ files, cwd })
 
   const names = new Set(['add', 'add2'])
 
@@ -95,7 +110,7 @@ test('js-esm', async () => {
   const cwd = join(import.meta.url, '..', 'fixtures', 'js-esm')
   const files = await glob('**/*.test.js', { cwd, absolute: true })
 
-  const stream = run({ files, cwd })
+  const stream = runIsolated({ files, cwd })
 
   const names = new Set(['add', 'add2'])
 


### PR DESCRIPTION
## Summary

- Running `npm run unit` emitted `Warning: node:test run() is being called recursively within a test file. skipping running files.` from `test/basic.test.js`, which imports `node:test`'s `run()` to exercise borp. Node's recursion guard ([nodejs/node@d5c9adf3df](https://github.com/nodejs/node/commit/d5c9adf3df)) skipped spawning files, so the `stream.on('test:pass', …)` assertions inside those tests never executed — they trivially passed against an empty stream.
- Wrapped each inner `run()` call in a `runIsolated()` helper that briefly clears `NODE_TEST_CONTEXT` for the synchronous portion of `run()` (the `parseCommandLine()` at `runner.js:916` and the recursion check at `runner.js:992`) and restores it immediately. Children spawned later still get `NODE_TEST_CONTEXT=child-v8` from the default at `runner.js:496`.
- Clearing `NODE_TEST_CONTEXT` at module scope (the obvious shortcut) also fools `lazyBootstrapRoot` (`harness.js:339`) into installing a spec reporter on stdout, which corrupts the v8-serialized stream the parent borp process reads — confirmed by a duplicated `tests 6` block and the outer total dropping from 35 → 30. The helper avoids that by toggling only at the call site.
- Added Node 26 to the CI matrix.

## Test plan

- [x] `npm run unit` — 35 tests pass, single summary, no recursion warning
- [ ] CI passes on Node 22 / 24 / 25 / 26 (ubuntu + windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)